### PR TITLE
Specify how long the email may take to arrive.

### DIFF
--- a/app/recovery/verify-email.html
+++ b/app/recovery/verify-email.html
@@ -9,7 +9,7 @@
         <span ng-if="! vm.anotherSent">an</span>
         <span ng-if="vm.anotherSent" class="md-body-2">another</span>
 
-        email with a verification code shortly, please enter it below.
+        email with a verification code in 1 - 2 minutes, please enter it below.
     </p>
 
     <!-- TODO: couldn't figure out a better way to keep the input from resizing when something is entered.  Width is the length of the longest code -->
@@ -38,4 +38,3 @@
         </md-button>
     </section>
 </form>
-


### PR DESCRIPTION
We received feedback that, with the current wording (and with how fast Google is at sending such emails), the user expects to receive the email right away. Given our current architecture, it could take a minute or two for them to receive the email. Giving the user a specific time frame reduces fears that something went wrong if they don't get the email for over a minute.