### PR TITLE
Fix error message where support phone not available

### DIFF
--- a/app/forgot/forgot.controller.js
+++ b/app/forgot/forgot.controller.js
@@ -59,11 +59,8 @@
             }
 
             var message = 'An account was not found for the username or email address you provided. Please try again with a different work email address or just your username. If you continue to have problems please contact support at ' + vm.config.support.email;
-            if (vm.config.support.phone) {
-                message += ' or ' + vm.config.support.phone + '.';
-            } else {
-                message += '.';
-            }
+            if (vm.config.support.phone) message += ' or ' + vm.config.support.phone;
+            message += '.';
 
             dialogService
                 .info(message, 'Account not found')

--- a/app/forgot/forgot.controller.js
+++ b/app/forgot/forgot.controller.js
@@ -62,7 +62,7 @@
             if (typeof vm.config.support.phone === 'undefined') {
               message += '.';
             } else {
-              message += ' or ' + phone + '.';
+              message += ' or ' + vm.config.support.phone + '.';
             }
 
             dialogService

--- a/app/forgot/forgot.controller.js
+++ b/app/forgot/forgot.controller.js
@@ -59,7 +59,7 @@
             }
 
             var message = 'An account was not found for the username or email address you provided. Please try again with a different work email address or just your username. If you continue to have problems please contact support at ' + vm.config.support.email;
-            if (vm.config.support.phone) { message += ' or ' + vm.config.support.phone };
+            if (vm.config.support.phone) { message += ' or ' + vm.config.support.phone }
             message += '.';
 
             dialogService

--- a/app/forgot/forgot.controller.js
+++ b/app/forgot/forgot.controller.js
@@ -59,10 +59,10 @@
             }
 
             var message = 'An account was not found for the username or email address you provided. Please try again with a different work email address or just your username. If you continue to have problems please contact support at ' + vm.config.support.email;
-            if (typeof vm.config.support.phone === 'undefined') {
-              message += '.';
+            if (vm.config.support.phone) {
+                message += ' or ' + vm.config.support.phone + '.';
             } else {
-              message += ' or ' + vm.config.support.phone + '.';
+                message += '.';
             }
 
             dialogService

--- a/app/forgot/forgot.controller.js
+++ b/app/forgot/forgot.controller.js
@@ -59,7 +59,7 @@
             }
 
             var message = 'An account was not found for the username or email address you provided. Please try again with a different work email address or just your username. If you continue to have problems please contact support at ' + vm.config.support.email;
-            if (vm.config.support.phone) message += ' or ' + vm.config.support.phone;
+            if (vm.config.support.phone) { message += ' or ' + vm.config.support.phone };
             message += '.';
 
             dialogService

--- a/app/forgot/forgot.controller.js
+++ b/app/forgot/forgot.controller.js
@@ -59,7 +59,9 @@
             }
 
             var message = 'An account was not found for the username or email address you provided. Please try again with a different work email address or just your username. If you continue to have problems please contact support at ' + vm.config.support.email;
-            if (vm.config.support.phone) { message += ' or ' + vm.config.support.phone }
+            if (vm.config.support.phone) {
+                message += ' or ' + vm.config.support.phone;
+            }
             message += '.';
 
             dialogService

--- a/app/forgot/forgot.controller.js
+++ b/app/forgot/forgot.controller.js
@@ -58,8 +58,15 @@
                 return dialogService.reset(primaryEmail, resetId);
             }
 
+            var message = 'An account was not found for the username or email address you provided. Please try again with a different work email address or just your username. If you continue to have problems please contact support at ' + vm.config.support.email;
+            if (typeof vm.config.support.phone === 'undefined') {
+              message += '.';
+            } else {
+              message += ' or ' + phone + '.';
+            }
+
             dialogService
-                .info('An account was not found for the username or email address you provided. Please try again with a different work email address or just your username. If you continue to have problems please contact support at ' + vm.config.support.email + ' or ' + vm.config.support.phone + '.', 'Account not found')
+                .info(message, 'Account not found')
                 .then(function () {
                     $route.reload();
                 });


### PR DESCRIPTION
The error message given for an undefined user name shows 'undefined' for the support phone number, if not supplied.

![account not found](https://user-images.githubusercontent.com/3172830/45241966-5a193f80-b2bc-11e8-9550-bf90d3622b07.png)

The patch ends the message with the email address if phone is undefined.
